### PR TITLE
[Rainloop] increased file upload size to 128M

### DIFF
--- a/rainloop/Dockerfile
+++ b/rainloop/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://ftp.fr.debian.org/debian $RELEASE main contrib non-free" > 
     && apt-get update \
     && apt-get -y upgrade
 
-RUN apt-get install -y --no-install-recommends runit curl git ca-certificates apt-utils apt-transport-https lsb-release unzip nginx php5-fpm php5-curl php5-pgsql php5-mysql php5-sqlite php5-json 
+RUN apt-get install -y --no-install-recommends runit curl git ca-certificates apt-utils apt-transport-https lsb-release unzip nginx php5-fpm php5-curl php5-pgsql php5-mysql php5-sqlite php5-json
 
 # Adding files
 ADD . /docker
@@ -26,7 +26,9 @@ RUN mkdir -p /webapps/rainloop /webapps/logs/rainloop && \
     cp -f /docker/assets/conf/nginx.conf /etc/nginx/nginx.conf &&  \
     cp -f /docker/assets/conf/nginx-rainloop.conf /etc/nginx/sites-available/rainloop.conf &&  \
     ln -s /etc/nginx/sites-available/rainloop.conf /etc/nginx/sites-enabled/rainloop.conf && \
-    sed -i 's/;daemonize = yes/daemonize = no/g' /etc/php5/fpm/php-fpm.conf
+    sed -i 's/;daemonize = yes/daemonize = no/g' /etc/php5/fpm/php-fpm.conf && \
+    sed -i 's/post_max_size.*$/post_max_size = 128M/g' /etc/php5/fpm/php.ini && \
+    sed -i 's/upload_max_filesize.*$/upload_max_filesize = 128M/g' /etc/php5/fpm/php.ini
 
 # "Configure services"
 # Based on https://github.com/mingfang/docker-salt
@@ -38,4 +40,3 @@ CMD /usr/sbin/runsvdir-start
 
 # Expose services
 EXPOSE 80
-


### PR DESCRIPTION
I'd like to increase the file upload size, which is limited by php-fpm's php.ini file.