### PR TITLE
[Rainloop] allowing nginx body size to be 128M

### DIFF
--- a/rainloop/assets/conf/nginx-rainloop.conf
+++ b/rainloop/assets/conf/nginx-rainloop.conf
@@ -5,6 +5,7 @@ server {
     access_log /webapps/logs/rainloop/access.log;
     error_log /webapps/logs/rainloop/error.log;
     index index.php;
+    client_max_body_size 128M;
 
     location ~ /\.ht {
         deny all;


### PR DESCRIPTION
This is an addition to #7, which did only set the 128M for PHP. This does also set it for nginx.